### PR TITLE
Export the Unifi-defined name field as hostname, and do not export RSSI and Noise metrics for wired clients

### DIFF
--- a/stationcollector.go
+++ b/stationcollector.go
@@ -171,7 +171,7 @@ func (c *StationCollector) collectStationBytes(ch chan<- prometheus.Metric, site
 // collectStationSignal collects wireless signal strength for UniFi stations.
 func (c *StationCollector) collectStationSignal(ch chan<- prometheus.Metric, siteLabel string, stations []*unifi.Station) {
 	for _, s := range stations {
-		if s.APMAC.String() == "" {
+		if s.IsWired {
 			continue
 		}
 		labels := []string{

--- a/stationcollector.go
+++ b/stationcollector.go
@@ -124,9 +124,8 @@ func (c *StationCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Des
 func hostName(s *unifi.Station) string {
 	if s.Name != "" {
 		return s.Name
-	} else {
-		return s.Hostname
 	}
+	return s.Hostname
 }
 
 // collectStationBytes collects receive and transmit byte counts for UniFi stations.

--- a/stationcollector_test.go
+++ b/stationcollector_test.go
@@ -53,6 +53,38 @@ func TestStationCollector(t *testing.T) {
 			}},
 		},
 		{
+			desc: "one wired station, one site",
+			input: strings.TrimSpace(`
+{
+	"data": [
+		{
+			"_id": "abcdef",
+			"mac": "de:ad:be:ef:de:ad",
+			"hostname": "foo",
+			"rx_bytes": 10,
+			"rx_packets": 1,
+			"tx_bytes": 20,
+			"tx_packets": 2
+		}
+	]
+}
+`),
+			matches: []*regexp.Regexp{
+				regexp.MustCompile(`unifi_stations{site="Default"} 1`),
+
+				regexp.MustCompile(`unifi_stations_received_bytes_total{ap_mac="",hostname="foo",id="abcdef",site="Default",station_mac="de:ad:be:ef:de:ad"} 10`),
+				regexp.MustCompile(`unifi_stations_transmitted_bytes_total{ap_mac="",hostname="foo",id="abcdef",site="Default",station_mac="de:ad:be:ef:de:ad"} 20`),
+
+				regexp.MustCompile(`unifi_stations_received_packets_total{ap_mac="",hostname="foo",id="abcdef",site="Default",station_mac="de:ad:be:ef:de:ad"} 1`),
+				regexp.MustCompile(`unifi_stations_transmitted_packets_total{ap_mac="",hostname="foo",id="abcdef",site="Default",station_mac="de:ad:be:ef:de:ad"} 2`),
+
+			},
+			sites: []*unifi.Site{{
+				Name:        "default",
+				Description: "Default",
+			}},
+		},
+		{
 			desc: "two stations, one site",
 			input: strings.TrimSpace(`
 {

--- a/stationcollector_test.go
+++ b/stationcollector_test.go
@@ -77,7 +77,6 @@ func TestStationCollector(t *testing.T) {
 
 				regexp.MustCompile(`unifi_stations_received_packets_total{ap_mac="",hostname="foo",id="abcdef",site="Default",station_mac="de:ad:be:ef:de:ad"} 1`),
 				regexp.MustCompile(`unifi_stations_transmitted_packets_total{ap_mac="",hostname="foo",id="abcdef",site="Default",station_mac="de:ad:be:ef:de:ad"} 2`),
-
 			},
 			sites: []*unifi.Site{{
 				Name:        "default",


### PR DESCRIPTION
The current hostname exported is the client-provided name, which is often much less descriptive (or nonexistence) compared to what I've set in the Unifi interface. This patch exports the Unifi hostname if provided, otherwise it uses the client provided hostname.

It also stops exporting metrics for wired clients with no AP MAC set.