### PR TITLE
Correcting the comments for transmit and receive metrics

### DIFF
--- a/stationcollector.go
+++ b/stationcollector.go
@@ -58,28 +58,28 @@ func NewStationCollector(c *unifi.Client, sites []*unifi.Site) *StationCollector
 
 		ReceivedBytesTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "received_bytes_total"),
-			"Number of bytes received by stations (client download)",
+			"Number of bytes received by the AP for stations (client upload)",
 			labelsStation,
 			nil,
 		),
 
 		TransmittedBytesTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transmitted_bytes_total"),
-			"Number of bytes transmitted by stations (client upload)",
+			"Number of bytes transmitted by the AP to stations (client download)",
 			labelsStation,
 			nil,
 		),
 
 		ReceivedPacketsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "received_packets_total"),
-			"Number of packets received by stations (client download)",
+			"Number of packets received by the AP for stations (client upload)",
 			labelsStation,
 			nil,
 		),
 
 		TransmittedPacketsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transmitted_packets_total"),
-			"Number of packets transmitted by stations (client upload)",
+			"Number of packets transmitted by the AP for stations (client download)",
 			labelsStation,
 			nil,
 		),


### PR DESCRIPTION
These mean the opposite of what one would expect.
Transmit is the client's RX, and Receive is the client's TX.

Check your own stats to make sure I'm not insane, but I am positive on my setup that these are counters from the AP's perspective, not the wireless client.
