### PR TITLE
Setting the default user to "nobody" in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:latest
 
 EXPOSE 9130
-CMD ["/bin/unifi_exporter"]
 
 RUN apk update ; apk add go ; apk add git ; apk add musl-dev ; \
     go get github.com/mdlayher/unifi_exporter/cmd/unifi_exporter; \
     mv ~/go/bin/unifi_exporter /bin/
+
+USER nobody
+ENTRYPOINT ["/bin/unifi_exporter"]


### PR DESCRIPTION
Changing CMD to ENTRYPOINT so that commandline arguments can be passed to unifi_exporter without specifying the binary. I think the docker-compose.yaml file won't work without this.