### PR TITLE
Improve Makefile & Dockerfile to push docker image on successful build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /unifi_exporter
+coverage.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ before_install:
   - go get github.com/golang/lint/golint
 before_script:
   - go get -d ./...
+
 script:
-  - golint ./...
-  - go vet ./...
-  - go test -v ./...
+  - make fmt vet lint test build
   - if ! $HOME/gopath/bin/goveralls -service=travis-ci -repotoken $COVERALLS_TOKEN; then echo "Coveralls not available."; fi
-  - go build ./...
+
+after_success:
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push mdlayher/unifi_exporter;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.6
+  - 1.8
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM alpine:latest
+FROM golang:alpine AS build
+ADD . /go/src/github.com/mdlayher/unifi_exporter
+WORKDIR /go/src/github.com/mdlayher/unifi_exporter
+RUN apk --update add make
 
-EXPOSE 9130
+RUN make build
 
-RUN apk update ; apk add go ; apk add git ; apk add musl-dev ; \
-    go get github.com/mdlayher/unifi_exporter/cmd/unifi_exporter; \
-    mv ~/go/bin/unifi_exporter /bin/
+FROM alpine
+WORKDIR /app
+COPY --from=build /go/src/github.com/mdlayher/unifi_exporter /bin/
 
 USER nobody
+EXPOSE 9130
 ENTRYPOINT ["/bin/unifi_exporter"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,27 @@
+GO := CGO_ENABLED=0 go
+PACKAGES = $(shell go list ./... | grep -v /vendor/)
+
 .PHONY: all 
+all: fmt vet lint test build
+
+.PHONY: fmt
+fmt:
+	$(GO) fmt $(PACKAGES)
+
+.PHONY: vet
+vet:
+	$(GO) vet $(PACKAGES)
+
+.PHONY: lint
+lint:
+	@which golint > /dev/null; if [ $$? -ne 0 ]; then \
+		$(GO) get -u github.com/golang/lint/golint; \
+	fi
+	for PKG in $(PACKAGES); do golint -set_exit_status $$PKG || exit 1; done;
+
+.PHONY: test
+test:
+	@for PKG in $(PACKAGES); do go test -v -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || exit 1; done;
 
 build:
 	go build ./cmd/unifi_exporter


### PR DESCRIPTION
I also incorporated multi step builds. Like this the binary will be build inside an `golang:alpine` container but once that's done, it's copied to a normal `alpine:latest`. This will reduce the containers file size from 100MB to 12MB.

Everything that's left to do for automatic pushes to DockerHub is to add credentials to the environment: `$DOCKER_USERNAME` & `$DOCKER_PASSWORD`