### PR TITLE
Remove build deps after build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM alpine:latest
 
 EXPOSE 9130
 
-RUN apk update ; apk add go ; apk add git ; apk add musl-dev ; \
-    go get github.com/mdlayher/unifi_exporter/cmd/unifi_exporter; \
-    mv ~/go/bin/unifi_exporter /bin/
+RUN apk add --update --virtual build-deps go git musl-dev && \
+    go get github.com/mdlayher/unifi_exporter/cmd/unifi_exporter && \
+    mv ~/go/bin/unifi_exporter /bin/ && \
+    apk del build-deps && \
+    rm -rf /var/cache/apk/* ~/go/
 
 USER nobody
 ENTRYPOINT ["/bin/unifi_exporter"]


### PR DESCRIPTION
This shrinks the docker image from 300+ MB to 14 MB.